### PR TITLE
fixing caret offset issue

### DIFF
--- a/agent/static/app.css
+++ b/agent/static/app.css
@@ -28,7 +28,8 @@ button {
 	width: 66%;
 }
 
-#editor { 
+#editor {
+    font-family:monospace!important;
     position: absolute;
     top: 0;
     right: 0;


### PR DESCRIPTION
The caret seems to be flashing at a offset location to where the character appears. According to a previous issue https://github.com/ajaxorg/ace/issues/1078, ACE editor doesn't seems to like any fonts that is not from the monospace family.
