### PR TITLE
Allow using `pkill -HUP dnsmasq` command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV WEBPROC_URL https://github.com/jpillora/webproc/releases/download/$WEBPROC_V
 # fetch dnsmasq and webproc binary
 RUN apk update \
 	&& apk --no-cache add dnsmasq \
-	&& apk add --no-cache --virtual .build-deps curl \
+	&& apk add --no-cache --virtual .build-deps curl procps \
 	&& curl -sL $WEBPROC_URL | gzip -d - > /usr/local/bin/webproc \
 	&& chmod +x /usr/local/bin/webproc \
 	&& apk del .build-deps

--- a/README.md
+++ b/README.md
@@ -57,6 +57,14 @@ dnsmasq in a docker container, configurable via a [simple web UI](https://github
    myhost.company has address 10.0.0.2
    ```
 
+1. Apply new DNS records
+
+   You can reload the dnsmasq service without restarting the container with the following command:
+
+   ```
+   docker exec dnsmasq pkill -HUP dnsmasq
+   ```
+
 #### MIT License
 
 Copyright &copy; 2018 Jaime Pillora &lt;dev@jpillora.com&gt;

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 dnsmasq in a docker container, configurable via a [simple web UI](https://github.com/jpillora/webproc)
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/jpillora/dnsmasq.svg)][dockerhub]
-[![Image Size](https://images.microbadger.com/badges/image/jpillora/dnsmasq.svg)][dockerhub]
 
 ### Usage
 


### PR DESCRIPTION
Installed `procps` package that provides the `pkill` command. 
Now we can be able to reload DNS records without restarting the entire Docker container