### PR TITLE
^ #0; bump to webproc 0.4.0 and dnsmasq 2.91

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM alpine:edge
 LABEL maintainer="dev@jpillora.com"
 # webproc release settings
-ENV WEBPROC_VERSION 0.2.2
-ENV WEBPROC_URL https://github.com/jpillora/webproc/releases/download/$WEBPROC_VERSION/webproc_linux_amd64.gz
+ENV WEBPROC_VERSION 0.4.0
+ENV WEBPROC_URL "https://github.com/jpillora/webproc/releases/download/v${WEBPROC_VERSION}/webproc_${WEBPROC_VERSION}_linux_amd64.gz"
 # fetch dnsmasq and webproc binary
 RUN apk update \
 	&& apk --no-cache add dnsmasq \
@@ -15,4 +15,4 @@ RUN mkdir -p /etc/default/
 RUN echo -e "ENABLED=1\nIGNORE_RESOLVCONF=yes" > /etc/default/dnsmasq
 COPY dnsmasq.conf /etc/dnsmasq.conf
 #run!
-ENTRYPOINT ["webproc","--config","/etc/dnsmasq.conf","--","dnsmasq","--no-daemon"]
+ENTRYPOINT ["webproc","--configuration-file","/etc/dnsmasq.conf","--","dnsmasq","--no-daemon"]


### PR DESCRIPTION
Hi, @jpillora , this tool is very useful !

But I found that the version used by this application is relatively old, so I updated the software and base system versions:

webproc: 0.2.2 -> 0.4.0
dnsmasq: 2.80 -> 2.91
And combine dnsmasq configuration into Dockerfile, removed some unnecessary configuration, move some parameters to the startup process.

Hope these are helpful to the project.